### PR TITLE
Include 'create_potransaction' in the list of available functions

### DIFF
--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -14,6 +14,7 @@ module IntacctRuby
       update
       delete
       getAPISession
+      create_potransaction
     ).freeze
 
     CU_TYPES = %w(create update).freeze


### PR DESCRIPTION
Include 'create_potransaction' in the list of available functions
