### PR TITLE
[ENT-789] Include 'create_supdoc' in the functions list

### DIFF
--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -15,6 +15,7 @@ module IntacctRuby
       delete
       getAPISession
       create_potransaction
+      create_supdoc
     ).freeze
 
     CU_TYPES = %w(create update).freeze


### PR DESCRIPTION
Included `create_supdoc` in the functions list to support creating attachments in Sage
https://developer.intacct.com/api/company-console/attachments/#create-attachment-legacy